### PR TITLE
fix: correctly deserialize HoverContents from 2-length array

### DIFF
--- a/src/hover.rs
+++ b/src/hover.rs
@@ -80,7 +80,7 @@ pub struct Hover {
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HoverContents {
-    Scalar(MarkedString),
     Array(Vec<MarkedString>),
+    Scalar(MarkedString),
     Markup(MarkupContent),
 }


### PR DESCRIPTION
This PR is for bringing https://github.com/gluon-lang/lsp-types/pull/296 to Zed before it gets merged upstream. IMHO it's both simple and critical enough to be cherry-picked earlier 😅 