### PR TITLE
Fix wrong result type for inline value request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -871,7 +871,7 @@ pub enum InlineValueRequest {}
 
 impl Request for InlineValueRequest {
     type Params = InlineValueParams;
-    type Result = Option<InlineValue>;
+    type Result = Option<Vec<InlineValue>>;
     const METHOD: &'static str = "textDocument/inlineValue";
 }
 


### PR DESCRIPTION
See example result from language server:

```json
[
  {
    "range": { "start": { "line": 21, "character": 15 }, "end": { "line": 21, "character": 20 } },
    "variableName": "$this",
    "caseSensitiveLookup": true
  },
  ...
]
```