### PR TITLE
Add workspace diagnostic progress variant

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::NumberOrString;
 
@@ -13,13 +14,7 @@ pub struct ProgressParams {
     pub token: ProgressToken,
 
     /// The progress data.
-    pub value: ProgressParamsValue,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
-#[serde(untagged)]
-pub enum ProgressParamsValue {
-    WorkDone(WorkDoneProgress),
+    pub value: Value,
 }
 
 /// The `window/workDoneProgress/create` request is sent

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
-use crate::NumberOrString;
+use crate::{NumberOrString, WorkspaceDiagnosticReportResult};
 
 pub type ProgressToken = NumberOrString;
 
@@ -14,7 +13,14 @@ pub struct ProgressParams {
     pub token: ProgressToken,
 
     /// The progress data.
-    pub value: Value,
+    pub value: ProgressParamsValue,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum ProgressParamsValue {
+    WorkDone(WorkDoneProgress),
+    WorkspaceDiagnostic(WorkspaceDiagnosticReportResult),
 }
 
 /// The `window/workDoneProgress/create` request is sent


### PR DESCRIPTION
The field `ProgressParams.value` has a lot of possible values and it seems to not be worth it to make a variant for each of those in the old `ProgressParamsValue` enum. With this change, users can make their own enum like `ProgressParamsValue` containing what they need, and convert between that and `Value`. The current solution isn't enough because for PR https://github.com/zed-industries/zed/pull/34022 we need the ability to grab a `WorkspaceDiagnosticReportResult` from `ProgressParams`.