### PR TITLE
Update CodeDescription href to be optional with custom deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT"
 bitflags = "1.0.1"
 serde = { version = "1.0.34", features = ["derive"] }
 serde_json = "1.0.50"
-serde_repr = "0.1"
 url = {version = "2.0.0", features = ["serde"]}
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@ extern crate bitflags;
 
 use std::{collections::HashMap, fmt::Debug};
 
-use serde::{de::{self, Error as Error_}, Deserialize, Deserializer, Serialize};
+use serde::{
+    de::{self, Error as Error_},
+    Deserialize, Deserializer, Serialize,
+};
 use serde_json::Value;
 pub use url::Url;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate bitflags;
 
 use std::{collections::HashMap, fmt::Debug};
 
-use serde::{de, de::Error as Error_, Deserialize, Serialize};
+use serde::{de::{self, Error as Error_}, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 pub use url::Url;
 
@@ -424,10 +424,24 @@ pub struct Diagnostic {
     pub data: Option<serde_json::Value>,
 }
 
+fn deserialize_optional_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    match opt {
+        Some(s) if s.is_empty() => Ok(None),
+        Some(s) => Url::parse(&s).map(Some).map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeDescription {
-    pub href: Url,
+    #[serde(deserialize_with = "deserialize_optional_url")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub href: Option<Url>,
 }
 
 impl Diagnostic {


### PR DESCRIPTION
This is to fix issues specific to deserialisation issues with href value inside of `CodeDescription` sent from eslint lsp server. We have made the href field optional so that it can handle empty string with custom deserialization. For more context check this comment: https://github.com/zed-industries/zed/pull/33814#issuecomment-3032616711 

ISSUES: https://github.com/zed-industries/zed/issues/33442

cc @SomeoneToIgnore can you please help review this. It will unblock: https://github.com/zed-industries/zed/pull/33814