### PR TITLE
Add textEditText field to CompletionItem

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -643,6 +643,17 @@ pub struct CompletionItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_edit: Option<CompletionTextEdit>,
 
+    /// The edit text used if the completion item is part of a CompletionList and
+    /// CompletionList defines an item default for the text edit range.
+    /// Clients will only honor this property if they opt into completion list
+    /// item defaults using the capability `completionList.itemDefaults`.
+    /// If not provided and a list's default range is provided the label
+    /// property is used as a text.
+    ///
+    /// @since 3.17.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_edit_text: Option<String>,
+
     /// An optional array of additional text edits that are applied when
     /// selecting this completion. Edits must not overlap with the main edit
     /// nor with themselves.


### PR DESCRIPTION
According to the [Official LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#:~:text=/**%0A%09%20*%20The%20edit%20text,%3F%3A%20string%3B) 

Please also see [this PR](https://github.com/zed-industries/zed/pull/41166) for context.

This is the same change already merged to master, but zed does not use the master branch it turns out.