### PR TITLE
Allow extended fold types

### DIFF
--- a/src/folding_range.rs
+++ b/src/folding_range.rs
@@ -2,7 +2,8 @@ use crate::{
     PartialResultParams, StaticTextDocumentColorProviderOptions, TextDocumentIdentifier,
     WorkDoneProgressParams,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FoldingRangeParams {
@@ -100,8 +101,7 @@ pub struct FoldingRangeClientCapabilities {
 }
 
 /// Enum of known range kinds
-#[derive(Debug, Eq, PartialEq, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum FoldingRangeKind {
     /// Folding range for a comment
     Comment,
@@ -109,6 +109,37 @@ pub enum FoldingRangeKind {
     Imports,
     /// Folding range for a region (e.g. `#region`)
     Region,
+    /// Folding range for other kinds, as certain language servers may extend the defined list.
+    Other(String),
+}
+
+impl<'de> Deserialize<'de> for FoldingRangeKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "comment" => Self::Comment,
+            "imports" => Self::Imports,
+            "region" => Self::Region,
+            _ => Self::Other(s.to_lowercase()),
+        })
+    }
+}
+
+impl Serialize for FoldingRangeKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::Comment => "comment",
+            Self::Imports => "imports",
+            Self::Region => "region",
+            Self::Other(s) => s,
+        })
+    }
 }
 
 /// Represents a folding range.


### PR DESCRIPTION
`json-language-server` returns `object` as a folding range kind:

<img width="1728" height="720" alt="bad" src="https://github.com/user-attachments/assets/ee574879-8657-41c8-ab12-562f3882f057" />

The spec, even 3.18, does not really seem to allow it explicitly: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#foldingRangeKind

but mentions that the real type

> The type is a string since the value set is extensible

The PR adds a capture enum variant for such cases, to get the folds in instead of failing on deserialization.