### PR TITLE
clangd: Code completion scores

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -550,6 +550,12 @@ pub struct CompletionItem {
     /// Tags for this completion item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<CompletionItemTag>>,
+
+    /// A score that represents the quality of the completion item.
+    ///
+    /// @since clangd extension
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
 }
 
 impl CompletionItem {


### PR DESCRIPTION
Clangd provides score field in response to "textDocument/completion". This field could be used to calculate completion score as it is noted in clangd extension documentation. After this merged, I am planning to add this score calculation to Zed for C++.

[Clangd Protocol Extensions:](https://clangd.llvm.org/extensions)
"Clients that fuzzy client-side filtering should multiply score by their fuzzy-match score and sort by the result."

[clangd-score.txt](https://github.com/user-attachments/files/25462043/clangd-score.txt)