### PR TITLE
fix: add skip_serializing_if to optional fields

### DIFF
--- a/src/document_diagnostic.rs
+++ b/src/document_diagnostic.rs
@@ -81,11 +81,11 @@ pub struct DocumentDiagnosticParams {
     pub text_document: TextDocumentIdentifier,
 
     /// The additional identifier provided during registration.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 
     /// The result ID of a previous response if provided.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_result_id: Option<String>,
 
     #[serde(flatten)]

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -83,6 +83,7 @@ pub struct FileOperationRegistrationOptions {
 #[serde(rename_all = "camelCase")]
 pub struct FileOperationFilter {
     /// A Uri like `file` or `untitled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scheme: Option<String>,
 
     /// The actual file operation pattern.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1392,6 +1392,7 @@ pub struct SymbolKindCapability {
     /// If this property is not present the client only supports
     /// the symbol kinds from `File` to `Array` as defined in
     /// the initial version of the protocol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value_set: Option<Vec<SymbolKind>>,
 }
 

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -378,6 +378,7 @@ pub struct SemanticTokensWorkspaceClientCapabilities {
     /// semantic tokens currently shown. It should be used with absolute care
     /// and is useful for situation where a server for example detect a project
     /// wide change that requires such a calculation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh_support: Option<bool>,
 }
 

--- a/src/workspace_diagnostic.rs
+++ b/src/workspace_diagnostic.rs
@@ -41,6 +41,7 @@ pub struct PreviousResultId {
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceDiagnosticParams {
     /// The additional identifier provided during registration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
 
     /// The currently known diagnostic reports with their


### PR DESCRIPTION
tsgo updated to be strict in not allowing null for optional fields: https://github.com/microsoft/typescript-go/issues/3336

This breaks compatibility with the Zed tsgo extension, this changes makes sure those fields are skipped if there's no value.

I've had Claude check all the fields against the spec and add this attribute for any fields that are defined as `field?: type`, but not for fields defined like `field: type | null`

Related: https://github.com/zed-extensions/tsgo/issues/42